### PR TITLE
Add authentication guards for shopper routes

### DIFF
--- a/components/auth/auth-card.tsx
+++ b/components/auth/auth-card.tsx
@@ -141,7 +141,7 @@ export function AuthCard({ mode }: { mode: "login" | "signup" }) {
 
       <p className="mt-5 text-center text-sm text-slate-600 dark:text-slate-300">
         {mode === "signup" ? "Already have an account?" : "New to Amazon?"}{" "}
-        <Link href={mode === "signup" ? "/login" : "/signup"} className="font-bold text-amazon-teal hover:text-amazon-orange">
+        <Link href={`${mode === "signup" ? "/login" : "/signup"}?callbackUrl=${encodeURIComponent(callbackUrl)}`} className="font-bold text-amazon-teal hover:text-amazon-orange">
           {mode === "signup" ? "Sign in" : "Create your account"}
         </Link>
       </p>

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -166,9 +166,20 @@ export function Header() {
             </button>
           </form>
           <div className="grid grid-cols-2 gap-2 text-sm">
-            <Link href="/login" className="rounded-md bg-white/10 px-3 py-2">
-              Sign in
-            </Link>
+            {session?.user ? (
+              <>
+                <Link href="/dashboard/profile" className="rounded-md bg-white/10 px-3 py-2">
+                  Profile
+                </Link>
+                <button type="button" onClick={() => signOut({ callbackUrl: "/" })} className="rounded-md bg-white/10 px-3 py-2 text-left">
+                  Logout
+                </button>
+              </>
+            ) : (
+              <Link href="/login" className="rounded-md bg-white/10 px-3 py-2">
+                Sign in
+              </Link>
+            )}
             <Link href="/dashboard/orders" className="rounded-md bg-white/10 px-3 py-2">
               Your orders
             </Link>

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,14 @@
+import { withAuth } from "next-auth/middleware";
+
+export default withAuth({
+  pages: {
+    signIn: "/login"
+  },
+  callbacks: {
+    authorized: ({ token }) => Boolean(token)
+  }
+});
+
+export const config = {
+  matcher: ["/checkout", "/dashboard/:path*"]
+};


### PR DESCRIPTION
Adds NextAuth middleware so checkout and dashboard routes redirect unauthenticated shoppers to the sign-in page, while preserving the callback URL through the login/signup switch. The mobile account menu now reflects the current session by showing profile/logout actions for signed-in users instead of always prompting them to sign in. Verified with `npm run typecheck`, `npm run build`, and `git diff --check`.
