### PR TITLE
Remove theme toggle

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,8 +6,10 @@
   color-scheme: light;
 }
 
-.dark {
-  color-scheme: dark;
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+  }
 }
 
 * {
@@ -35,9 +37,11 @@ body {
     "calt" 1;
 }
 
-.dark body {
-  background: #020617;
-  color: #e2e8f0;
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #020617;
+    color: #e2e8f0;
+  }
 }
 
 ::selection {

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,27 +1,21 @@
 "use client";
 
-import { Menu, Moon, Search, ShoppingCart, Sun, UserRound, X } from "lucide-react";
+import { Menu, Search, ShoppingCart, UserRound, X } from "lucide-react";
 import { signOut, useSession } from "next-auth/react";
-import { useTheme } from "next-themes";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { FormEvent, useEffect, useState } from "react";
+import { FormEvent, useState } from "react";
 
 import { useCartStore } from "@/components/providers/cart-store";
-import { Button } from "@/components/ui/button";
 import { categories } from "@/lib/data";
 
 export function Header() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { data: session } = useSession();
-  const { theme, setTheme } = useTheme();
   const cartCount = useCartStore((state) => state.count());
-  const [mounted, setMounted] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const [query, setQuery] = useState(searchParams.get("q") ?? "");
-
-  useEffect(() => setMounted(true), []);
 
   function onSearch(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -79,15 +73,6 @@ export function Header() {
         </form>
 
         <div className="ml-auto flex items-center gap-1 sm:gap-2">
-          <button
-            type="button"
-            onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-            className="hidden rounded-md p-2 hover:bg-white/10 sm:inline-flex"
-            aria-label="Toggle dark mode"
-          >
-            {mounted && theme === "dark" ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
-          </button>
-
           {session?.user ? (
             <div className="group relative hidden sm:block">
               <Link href="/dashboard/orders" className="flex items-center gap-2 rounded-md px-2 py-1.5 hover:bg-white/10">
@@ -183,14 +168,6 @@ export function Header() {
             <Link href="/dashboard/orders" className="rounded-md bg-white/10 px-3 py-2">
               Your orders
             </Link>
-            <Button
-              variant="ghost"
-              onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-              className="justify-start bg-white/10 text-white hover:bg-white/20"
-            >
-              {mounted && theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
-              Theme
-            </Button>
           </div>
         </div>
       )}

--- a/components/providers/app-providers.tsx
+++ b/components/providers/app-providers.tsx
@@ -1,16 +1,13 @@
 "use client";
 
 import { SessionProvider } from "next-auth/react";
-import { ThemeProvider } from "next-themes";
 import { Toaster } from "sonner";
 
 export function AppProviders({ children }: { children: React.ReactNode }) {
   return (
     <SessionProvider>
-      <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
-        {children}
-        <Toaster richColors closeButton position="top-right" />
-      </ThemeProvider>
+      {children}
+      <Toaster richColors closeButton position="top-right" />
     </SessionProvider>
   );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
-  darkMode: ["class"],
+  darkMode: "media",
   content: [
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",


### PR DESCRIPTION
## Description

This PR improves the navbar UX by removing the manual theme toggle buttons and simplifying the application's theme handling.

To better match Amazon's clean UI style, the desktop and mobile theme toggle controls were removed. Additionally, theme handling was refactored to rely entirely on the user's system preferences using native CSS media queries instead of runtime theme management.

---

## Changes Made

### `components/layout/header.tsx`
- Removed desktop theme toggle button
- Removed mobile theme toggle button
- Cleaned up unused imports and related logic
- Removed unused `mounted` state and `useEffect`

### `components/providers/app-providers.tsx`
- Removed the `next-themes` `ThemeProvider` wrapper

### `tailwind.config.ts`
- Updated Tailwind dark mode configuration:

```ts
darkMode: "media"
```

### `app/globals.css`
- Refactored dark mode styles to use native CSS media queries:

```css
@media (prefers-color-scheme: dark)
```

---

## Testing

- Verified desktop navbar layout after toggle removal
- Verified mobile navigation layout and spacing
- Confirmed OS-level dark/light mode switching applies styles correctly

---

## Related Issue

Fixes #10